### PR TITLE
Add GitHub issue template requisites

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,41 @@
+name: 🐞 Bug
+description: Something is not working as indended.
+labels: ["bug"]
+body:
+- type: textarea
+  attributes:
+    label: Current Behavior
+    description: What behavior you're experiencing.
+    placeholder: |
+      When I do <X>, <Y> happens and I see the error message attached below:
+      ```...```
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: What you expected to happen.
+    placeholder: When I do <X>, <Z> should happen instead.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Steps To Reproduce
+    description: Steps to reproduce the behavior.
+    placeholder: |
+      1. In this environment...
+      2. With this config...
+      3. Run '...'
+      4. See error...
+    render: markdown
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      - Operating system
+      - Java version
+  validations:
+    required: false
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions
+    url: https://discuss.vectara.com/
+    about: Ask questions and interact with the community here!
+

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,23 @@
+name: 💡 Enhancement
+description: Request a new feature
+labels: ["enhancement"]
+body:
+- type: textarea
+  attributes:
+    label: Requested Feature
+    description: Describe what feature/enhancement you would like to see
+    placeholder: |
+      When I do <X>, I would like <Y> to happen because <Z>
+      ```...```
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      - Use case
+      - Java version
+      - Would you be willing to try implementing the feature?
+  validations:
+    required: false
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+# Security Policy
+
+The Vectara trust and security center, including our security policy, can be found at
+[https://vectara.com/legal/security-at-vectara/](https://vectara.com/legal/security-at-vectara/).
+
+
+## Reporting a Vulnerability
+
+Please send security vulnerability reports to support@vectara.com.
+


### PR DESCRIPTION
This adds:
- 2 new issue templates: 1 for enhancements and 1 for bugs
- The required issue template config.yml, including how to get involved with the community
- A security reporting file to link to from the issue creation screen